### PR TITLE
Install simplecov and codecov

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,18 @@
 # frozen_string_literal: true
-require 'redis_record'
+require 'simplecov'
 
-Time.zone = 'UTC'
+SimpleCov.start
+
+if ENV['CI'] == 'true'
+  require 'codecov'
+  SimpleCov.formatter = SimpleCov::Formatter::Codecov
+end
 
 RSpec.configure do |config|
+  require 'redis_record'
+
+  Time.zone = 'UTC'
+
   config.before(:each) do
     RedisRecord::Base.redis.flushdb
   end

--- a/yarr.gemspec
+++ b/yarr.gemspec
@@ -22,5 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'sorbet-runtime', '>= 0.4.4704'
   s.add_dependency 'sorbet-static', '>= 0.4.4704'
 
+  s.add_development_dependency 'codecov'
   s.add_development_dependency 'rspec', '~> 3.2'
+  s.add_development_dependency 'simplecov'
 end


### PR DESCRIPTION
### Summary
This installs simplecov and codecov so we can attach a code coverage report on the PRs (we need to configure codecov.io for this repo).

### Test Plan
- [x] Locally run rspec. The code coverage is reported correctly.