### PR TITLE
Change the min ruby version to 2.5

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,2 @@
+AllCops:
+  TargetRubyVersion: 2.5

--- a/yarr.gemspec
+++ b/yarr.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.files         = Dir.glob('lib/**/*')
 
-  s.required_ruby_version = ['>= 2.4.0']
+  s.required_ruby_version = ['>= 2.5.0']
 
   s.add_dependency 'activesupport', '~> 5'
   s.add_dependency 'railties', '~> 5'


### PR DESCRIPTION
The current implementation has invalid ruby 2.4 syntax. For example:
```
def func
rescue
end
```
This becomes valid ruby after version 2.5. This PR changes the min ruby version to 2.5 and sets the `TargetRubyVersion` for rubocop.