### PR TITLE
Apply traject/pull/1429

### DIFF
--- a/lib/redis_record/relation.rb
+++ b/lib/redis_record/relation.rb
@@ -13,7 +13,17 @@ class RedisRecord::Relation
   sig { returns(T::Set[Symbol]) }
   attr_reader :select_attrs
 
+  # TODO: Add sig for []
   delegate :[], to: :to_a
+
+  sig do
+    type_parameters(:U).params(
+      blk: T.proc.params(arg0: RedisRecord::Base).returns(T.type_parameter(:U)),
+    ).returns(T::Array[T.type_parameter(:U)])
+  end
+  def map(&blk)
+    to_a.map(&blk)
+  end
 
   sig do
     params(


### PR DESCRIPTION
This applies the changes from https://github.com/FB-PLP/traject/pull/1429/files. We are removing the redis-record implementation from traject and starting to maintain it here in this repo.